### PR TITLE
Added namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,6 +18,7 @@ rootProject.allprojects {
 }
 apply plugin: 'com.android.library'
 android {
+    namespace "com.slins.flutterfft"
     compileSdkVersion 30
 
     defaultConfig {


### PR DESCRIPTION
So since recently (think since Android SDK 35 or last Android Studio update, but not sure) you have to specify a namespace, or you get an error when building,
[Info here](https://developer.android.com/build/configure-app-module#set-namespace)

The error:
```
Run flutter build appbundle --obfuscate --split-debug-info=./build

Running Gradle task 'bundleRelease'...                          

FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project :flutter_fft.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.
```


Also (but not so important) maybe you can look at:
Note: /home/runner/.pub-cache/git/flutter-fft-3ee0b7e6052ab2478f91568716c7b2ed1cb50ffb/android/src/main/java/com/slins/flutterfft/FlutterFftPlugin.java uses or overrides a deprecated API.
but no rush, as it doesn't throw any errors